### PR TITLE
feat: additional hosts

### DIFF
--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -68,7 +68,10 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=4096 # Increase Node.js heap size
       #   🛠️ =========================================================== 🛠️
-      #       Replace below with your hosting provider of choice!
+      #       Pick your hosting providers below.
+      #       Enable a provider by getting the required secrets and putting them into
+      #       your repository secrets under the corresponding names.
+      #       You can enable as many providers as you like - they will all be deployed sequentially
 
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
       #      ·                 Vercel example                  ·
@@ -102,6 +105,12 @@ jobs:
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
       #      ·                 Netlify example                 ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
+      #       Create a new site in your Netlify dashboard
+      #
+      #       Needed env variables:
+      #       NETLIFY_AUTH_TOKEN: https://docs.netlify.com/cli/get-started/#obtain-a-token-in-the-netlify-ui
+      #       NETLIFY_SITE_ID: In your site -> Site configuration -> Site ID
+      #
       - name: Install Netlify CLI
         if: ${{ env.NETLIFY_AUTH_TOKEN != '' && env.NETLIFY_SITE_ID != '' }}
         run: npm install netlify-cli -g
@@ -114,6 +123,14 @@ jobs:
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
       #      ·                 Couldflare pages example        ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
+      #       Create a new site in your Netlify dashboard
+      #
+      #       Needed env variables:
+      #       CLOUDFLARE_API_TOKEN: https://dash.cloudflare.com/profile/api-tokens
+      #       CLOUDFLARE_PROJECT_NAME: Name of your site
+      #       CLOUDFLARE_ACCOUNT_ID: Select a site and copy Account ID from the right sidebar
+      #       GITHUB_TOKEN is filled in automatically
+      #
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         if: ${{ env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != '' && env.CLOUDFLARE_PROJECT_NAME != '' }}
@@ -127,6 +144,10 @@ jobs:
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
       #      ·                 Surge.sh example                ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
+      #       Needed env variables:
+      #       SURGE_LOGIN: your surge email address
+      #       SURGE_TOKEN: run `surge token` in your terminal
+      #
       - name: Install Surge
         if: ${{ env.SURGE_LOGIN != '' && env.SURGE_TOKEN != '' }}
         run: npm install -g surge
@@ -142,6 +163,12 @@ jobs:
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
       #      ·                 Firebase hosting example        ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
+      #       Create a new project in your Firebase Console
+      #
+      #       Needed env variables:
+      #       FIREBASE_PROJECT_ID: can be seen in your projects overview, usually a dash-separated version of your project name
+      #       FIREBASE_TOKEN: npm i -g firebase-tools && firebase login:ci
+      #
       - name: Setup Firebase CLI
         if: ${{ env.FIREBASE_TOKEN != '' && env.FIREBASE_PROJECT_ID != '' }}
         run: npm install -g firebase-tools
@@ -151,7 +178,13 @@ jobs:
         run: |
           firebase deploy --only hosting --project ${{ secrets.FIREBASE_PROJECT_ID }} --token ${{ secrets.FIREBASE_TOKEN }} --public ./web/apps/minifront/dist
 
-      - name: Deploy 🚀
+      #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
+      #      ·                 Github Pages example            .
+      #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
+      #      This step will copy the minifront build to a gh-pages branch.
+      #      To deploy, enable Github Pages in your repository settings,
+      #      and follow the deployments link on your repository page.
+      - name: Deploy to GitHub Actions
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: ./web/apps/minifront/dist

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -108,11 +108,11 @@ jobs:
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
       #      ·                 Couldflare pages example        ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
-      - name: Publish
+      - name: Cloudflare
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
-          directory: dist # e.g. 'dist'
+          directory: ./web/apps/minifront/dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -139,7 +139,10 @@ jobs:
       - name: Setup Firebase CLI
         if: ${{ env.FIREBASE_TOKEN != '' && env.FIREBASE_PROJECT_ID != '' }}
         run: npm install -g firebase-tools
-
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          
       - name: Deploy to Firebase
         if: ${{ env.FIREBASE_TOKEN != '' && env.FIREBASE_PROJECT_ID != '' }}
         run: |

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -130,4 +130,4 @@ jobs:
         env:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        run: surge ./web/apps/minifront/dist
+        run: surge --project ./web/apps/minifront/dist

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -119,7 +119,7 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
-      #      ·                 Surge.sh example        ·
+      #      ·                 Surge.sh example                ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
       - name: Install Surge
         if: ${{ env.SURGE_LOGIN != '' && env.SURGE_TOKEN != '' }}
@@ -131,3 +131,19 @@ jobs:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
         run: surge --project ./web/apps/minifront/dist
+
+
+      #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
+      #      ·                 Firebase hosting example        ·
+      #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
+      - name: Setup Firebase CLI
+        if: ${{ env.FIREBASE_TOKEN != '' && env.FIREBASE_PROJECT_ID != '' }}
+        run: npm install -g firebase-tools
+
+      - name: Deploy to Firebase
+        if: ${{ env.FIREBASE_TOKEN != '' && env.FIREBASE_PROJECT_ID != '' }}
+        run: |
+          firebase deploy --only hosting --project ${{ secrets.FIREBASE_PROJECT_ID }} --token ${{ secrets.FIREBASE_TOKEN }} --public ./web/apps/minifront/dist
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -110,6 +110,7 @@ jobs:
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/pages-action@v1
+        if: ${{ env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != '' && env.CLOUDFLARE_PROJECT_NAME != '' }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -121,9 +122,11 @@ jobs:
       #      ·                 Surge.sh example        ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
       - name: Install Surge
+        if: ${{ env.SURGE_LOGIN != '' && env.SURGE_TOKEN != '' }}
         run: npm install -g surge
 
       - name: Deploy to Surge
+        if: ${{ env.SURGE_LOGIN != '' && env.SURGE_TOKEN != '' }}
         env:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - *
+      - '*'
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -108,7 +108,7 @@ jobs:
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
       #      ·                 Couldflare pages example        ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
-      - name: Cloudflare
+      - name: Deploy to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -116,3 +116,15 @@ jobs:
           projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
           directory: ./web/apps/minifront/dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
+      #      ·                 Surge.sh example        ·
+      #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
+      - name: Install Surge
+        run: npm install -g surge
+
+      - name: Deploy to Surge
+        env:
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        run: surge ./web/apps/minifront/dist

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -150,3 +150,8 @@ jobs:
         if: ${{ env.FIREBASE_TOKEN != '' && env.FIREBASE_PROJECT_ID != '' }}
         run: |
           firebase deploy --only hosting --project ${{ secrets.FIREBASE_PROJECT_ID }} --token ${{ secrets.FIREBASE_TOKEN }} --public ./web/apps/minifront/dist
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: ./web/apps/minifront/dist

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -11,6 +11,18 @@ on:
 
 jobs:
   build_and_deploy:
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_PROJECT_NAME: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+      SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
     runs-on: ubuntu-latest
     steps:
       #   🛠️ ========== Needed to build minifront ========== 🛠️
@@ -76,9 +88,6 @@ jobs:
         if: ${{ env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != '' && env.VERCEL_TOKEN != '' }}
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
         working-directory: ./web/apps/minifront/dist/
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Build Project Artifacts
         if: ${{ env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != '' && env.VERCEL_TOKEN != '' }}
@@ -99,9 +108,6 @@ jobs:
 
       - name: Deploy to Netlify
         if: ${{ env.NETLIFY_AUTH_TOKEN != '' && env.NETLIFY_SITE_ID != '' }}
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         run: |
           netlify deploy --dir=./web/apps/minifront/dist --prod
 
@@ -139,14 +145,8 @@ jobs:
       - name: Setup Firebase CLI
         if: ${{ env.FIREBASE_TOKEN != '' && env.FIREBASE_PROJECT_ID != '' }}
         run: npm install -g firebase-tools
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-          
+
       - name: Deploy to Firebase
         if: ${{ env.FIREBASE_TOKEN != '' && env.FIREBASE_PROJECT_ID != '' }}
         run: |
           firebase deploy --only hosting --project ${{ secrets.FIREBASE_PROJECT_ID }} --token ${{ secrets.FIREBASE_TOKEN }} --public ./web/apps/minifront/dist
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - *
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -104,3 +104,15 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         run: |
           netlify deploy --dir=./web/apps/minifront/dist --prod
+
+      #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
+      #      ·                 Couldflare pages example        ·
+      #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
+      - name: Publish
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+          directory: dist # e.g. 'dist'
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-minifront.yml
+++ b/.github/workflows/deploy-minifront.yml
@@ -12,8 +12,9 @@ on:
 jobs:
   build_and_deploy:
     env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -74,36 +75,36 @@ jobs:
       #       You can enable as many providers as you like - they will all be deployed sequentially
 
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
-      #      ·                 Vercel example                  ·
+      #      ·                 Vercel                  ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
       #       Create a new project in your Vercel console (choose this forked repo as the connected repo)
       #
       #       Needed env variables:
-      #       VERCEL_ORG_ID: Get from https://vercel.com/<TEAM NAME>/~/settings#team-id
+      #       VERCEL_TEAM_ID: Get from https://vercel.com/<TEAM NAME>/~/settings#team-id
       #       VERCEL_PROJECT_ID: Get from https://vercel.com/<TEAM NAME>/<PROJECT NAME>/settings
       #       VERCEL_TOKEN: Create one here https://vercel.com/<TEAM NAME>/<PROJECT NAME>/settings/environment-variables
       #
       - name: Install Vercel CLI
-        if: ${{ env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != '' && env.VERCEL_TOKEN != '' }}
+        if: ${{ env.VERCEL_TEAM_ID != '' && env.VERCEL_PROJECT_ID != '' && env.VERCEL_TOKEN != '' }}
         run: pnpm add --global vercel@latest
 
       - name: Pull Vercel Environment Information
-        if: ${{ env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != '' && env.VERCEL_TOKEN != '' }}
+        if: ${{ env.VERCEL_TEAM_ID != '' && env.VERCEL_PROJECT_ID != '' && env.VERCEL_TOKEN != '' }}
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
         working-directory: ./web/apps/minifront/dist/
 
       - name: Build Project Artifacts
-        if: ${{ env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != '' && env.VERCEL_TOKEN != '' }}
+        if: ${{ env.VERCEL_TEAM_ID != '' && env.VERCEL_PROJECT_ID != '' && env.VERCEL_TOKEN != '' }}
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
         working-directory: ./web/apps/minifront/dist/
 
       - name: Deploy Project Artifacts to Vercel
-        if: ${{ env.VERCEL_ORG_ID != '' && env.VERCEL_PROJECT_ID != '' && env.VERCEL_TOKEN != '' }}
+        if: ${{ env.VERCEL_TEAM_ID != '' && env.VERCEL_PROJECT_ID != '' && env.VERCEL_TOKEN != '' }}
         run: vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
         working-directory: ./web/apps/minifront/dist/
 
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
-      #      ·                 Netlify example                 ·
+      #      ·                 Netlify                 ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
       #       Create a new site in your Netlify dashboard
       #
@@ -121,7 +122,7 @@ jobs:
           netlify deploy --dir=./web/apps/minifront/dist --prod
 
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
-      #      ·                 Couldflare pages example        ·
+      #      ·                 Couldflare pages        ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
       #       Create a new site in your Netlify dashboard
       #
@@ -142,7 +143,7 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
-      #      ·                 Surge.sh example                ·
+      #      ·                 Surge.sh                ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
       #       Needed env variables:
       #       SURGE_LOGIN: your surge email address
@@ -161,7 +162,7 @@ jobs:
 
 
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
-      #      ·                 Firebase hosting example        ·
+      #      ·                 Firebase hosting        ·
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
       #       Create a new project in your Firebase Console
       #
@@ -179,7 +180,7 @@ jobs:
           firebase deploy --only hosting --project ${{ secrets.FIREBASE_PROJECT_ID }} --token ${{ secrets.FIREBASE_TOKEN }} --public ./web/apps/minifront/dist
 
       #      ┌· · · · · · · · · · · · · · · · · · · · · · · · ·┐
-      #      ·                 Github Pages example            .
+      #      ·                 Github Pages            .
       #      └· · · · · · · · · · · · · · · · · · · · · · · · ·┘
       #      This step will copy the minifront build to a gh-pages branch.
       #      To deploy, enable Github Pages in your repository settings,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This GitHub Action automates the build and deployment process for [Minifront](ht
 
 2. **Customize the Action**. Modify the `.github/workflows/deploy-minifront.yml` file:
      - Fill in environment variables for your desired hosting providers. You can use as many as you like, they will all be deployed sequentially.
-     - Update the secrets in your GitHub repository accordingly
+     - Update the secrets in your GitHub repository accordingly.
+     - Providers without configured secrets won't run.
+     - Github Pages are deployed automatically, but need to be enabled in your repository settings.
      - Change cron frequency as desired (given github free tier, you can deploy at most every 4 hours)
 
 3. **Enable GitHub Actions**. Make sure GitHub Actions are enabled in your forked repository (Settings > Actions > General).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This GitHub Action automates the build and deployment process for [Minifront](ht
 1. **Fork this repository** to your own GitHub account.
 
 2. **Customize the Action**. Modify the `.github/workflows/deploy-minifront.yml` file:
-     - Adjust your specific hosting provider
+     - Fill in environment variables for your desired hosting providers. You can use as many as you like, they will all be deployed sequentially.
      - Update the secrets in your GitHub repository accordingly
      - Change cron frequency as desired (given github free tier, you can deploy at most every 4 hours)
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,16 @@
+{
+  "hosting": {
+    "public": "./web/apps/minifront/dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
fixes #3 

- [x] Vercel
- [x] Netlify
- [x] Cloudflare pages
- [x] Firebase
- [x] Surge
- [x] Github pages (this may not be possible due to the way it's deployed) https://github.com/marketplace/actions/deploy-to-github-pages

Infeasible:
- Render - their CLI is interactive and doesn't support the flow to deploy a project in a non-TTY context. there's an open issue to support setting the API key through an environment variable, so might be possible in the future.

Excluded GCloud as redundant, and AWS as the setup necessary in AWS Console defeats the purpose of a simple action.